### PR TITLE
clarify ATC tool detection failure messages

### DIFF
--- a/src/modules/tools/atc/ATCHandler.cpp
+++ b/src/modules/tools/atc/ATCHandler.cpp
@@ -840,14 +840,14 @@ void ATCHandler::on_gcode_received(void *argument)
 				if (!laser_detect()) {
 			        THEKERNEL->call_event(ON_HALT, nullptr);
 			        THEKERNEL->set_halt_reason(ATC_NO_TOOL);
-			        THEKERNEL->streams->printf("ERROR: Tool confliction occured, please check tool rack!\n");
+			        THEKERNEL->streams->printf("ERROR: Unexpected tool absence detected, please check tool rack!\n");
 				}
 			} else if (gcode->subcode == 2) {
 				// check false
 				if (laser_detect()) {
 			        THEKERNEL->call_event(ON_HALT, nullptr);
 			        THEKERNEL->set_halt_reason(ATC_HAS_TOOL);
-			        THEKERNEL->streams->printf("ERROR: Tool confliction occured, please check tool rack!\n");
+			        THEKERNEL->streams->printf("ERROR: Unexpected tool presence detected, please check tool rack!\n");
 				}
 			} else if (gcode->subcode == 3) {
 				// check if the probe was triggered


### PR DESCRIPTION
Print different messages for when a tool was expected but not detected and when a tool was not expected but was detected.

For context: I just had my first ATC tool drop failure this morning while I was away from my Carvera and wasn't sure if it was due to:

- The laser mistakenly detecting the presence of a tool where the tool to be dropped was supposed to go, possibly because I'd just gotten done milling a part that threw a lot of aluminum chips, or:
- The ATC tried to drop the tool, failed, and the laser rightly detected that the tool had not been dropped

Having different messages for the two scenarios would help me know which of those two scenarios to start looking at first.

---

Side note: you guys are doing awesome work and I'm super excited about all the new firmware additions that dropped this past week! Y'all are awesome, keep it up

